### PR TITLE
Support containerisation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ POGLY_MODULES=pogly
 
 # When running in a container, set the DATA_PATH to a volume
 # DATA_PATH=file:///some/volume/path
+
+# When running in a container, set the PORT and HOST to the port and host of the container
+# PORT=12000
+# HOST=0.0.0.0
+
+# If running behind a proxy or load balancer that terminates SSL, set FORCE_SECURE to true
+# FORCE_SECURE=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22-slim
 
 WORKDIR /usr/app
 COPY package.json package-lock.json tsconfig.json ./

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import fastify from "fastify";
+import fastify, { type FastifyRequest } from "fastify";
 import fastifyOauth2 from "@fastify/oauth2";
 import fastifySecureSession from "@fastify/secure-session";
 import { randomUUID } from "node:crypto";
 import { getUser, setUser } from "./database";
-import proxy, { withSecure } from "./proxy";
+import proxy from "./proxy";
 
 const {
   TWITCH_CLIENT_ID,
@@ -19,6 +19,10 @@ if (!POGLY_HOST) throw new Error("POGLY_HOST is required");
 
 const server = fastify({
   genReqId: () => randomUUID(),
+});
+
+server.decorateRequest("secure", function (this: FastifyRequest) {
+  return this.protocol === "https" || process.env.FORCE_SECURE === "true";
 });
 
 server.addHook("preHandler", async (req, reply) => {
@@ -44,7 +48,7 @@ server.register(fastifyOauth2, {
     issuer: "https://id.twitch.tv/oauth2",
   },
   callbackUri: (req) =>
-    `${withSecure(req, "http")}://${req.host}/login/twitch/callback`,
+    `${req.secure() ? "https" : "http"}://${req.host}/login/twitch/callback`,
 });
 
 server.register(fastifySecureSession, {
@@ -188,10 +192,7 @@ await server.register(proxy, {
     .map((module) => module.trim()),
 });
 
-const port = Number.isNaN(Number(process.env.PORT))
-  ? 3000
-  : Number(process.env.PORT);
-
+const port = Number(process.env.PORT) || 3000;
 server.listen({ port, host: process.env.HOST }).then((res) => {
   console.log(`Server running on ${res.replace("[::1]", "localhost")}`);
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,12 +24,6 @@ const web = async (
   return reply;
 };
 
-export const withSecure = (req: FastifyRequest, prefix: string) => {
-  const isSecure =
-    req.protocol === "https" || process.env.FORCE_SECURE === "true";
-  return isSecure ? `${prefix}s` : prefix;
-};
-
 const ws = async (req: FastifyRequest, reply: FastifyReply) => {
   reply.hijack();
   req.server.proxy.ws(req.raw, req.socket, null, {}, (err) => {
@@ -108,7 +102,7 @@ const proxy = async (server: FastifyInstance, opts: Options) => {
       if (
         !modules.includes(url.searchParams.get("module") ?? "") ||
         url.searchParams.get("domain") !==
-          `${withSecure(req, "ws")}://${req.host}`
+          `${req.secure() ? "wss" : "ws"}://${req.host}`
       ) {
         console.error(`${signature(req)} invalid module`);
         return reply.status(400).send(new Error("Invalid module"));
@@ -151,7 +145,7 @@ const proxy = async (server: FastifyInstance, opts: Options) => {
         // Inject the user's details and modules into the root HTML response
         if (req.method === "GET" && /^\/($|\?)/.test(req.url)) {
           const html = new TextDecoder().decode(body);
-          const domain = `${withSecure(req, "ws")}://${req.host}`;
+          const domain = `${req.secure() ? "wss" : "ws"}://${req.host}`;
           const swap = modules.map((module) => ({ domain, module }));
           return Buffer.from(
             new TextEncoder().encode(

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -5,5 +5,9 @@ declare namespace NodeJS {
     readonly SESSION_SECRET?: string;
     readonly POGLY_HOST?: string;
     readonly POGLY_MODULES?: string;
+    readonly DATA_PATH?: string;
+    readonly PORT?: string;
+    readonly HOST?: string;
+    readonly FORCE_SECURE?: string;
   };
 }

--- a/src/types/fastify.d.ts
+++ b/src/types/fastify.d.ts
@@ -18,6 +18,10 @@ interface TwitchOAuth2 extends OAuth2Namespace {
 }
 
 declare module "fastify" {
+  interface FastifyRequest {
+    secure: () => boolean;
+  }
+
   interface FastifyInstance {
     twitchOauth2: TwitchOAuth2;
     proxy: httpProxy;


### PR DESCRIPTION
- Fastify secure session has a native dependency that doesn't have a build for alpine so I swapped the base image to bookworm slim.
- Host & port configuration via environment variables was required for proper loopback and egress in a container environment
- There was an issue with https/http mixing, i.e. TLS was terminated infront of the container so the server was seeing insecure requests and returning insecure URLs. I added a `FORCE_SECURE` environment variable that means that the server should provide secure `https` and `wss` URLs despite receiving insecure requests.
- The server uses `GET /database/ping` call to know when it's started via loopback. In a containerised environment, that loopback is now going through the proxy so I needed to punch a hole for the ping otherwise the server never started.